### PR TITLE
Add shortcut to run app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Specifics for this repo
 *.parkobj
 *.DAT
+*.lnk
 config.json
 output/
 test/

--- a/editor_app/auxiliaries.py
+++ b/editor_app/auxiliaries.py
@@ -16,7 +16,7 @@ from PIL import Image
 from PIL.ImageQt import ImageQt
 import sys
 import io
-from os.path import abspath, join
+from os.path import abspath, join, dirname
 
 from pkgutil import get_data
 
@@ -32,7 +32,7 @@ def resource_path(relative_path):
         # PyInstaller creates a temp folder and stores path in _MEIPASS
         base_path = sys._MEIPASS
     except Exception:
-        base_path = abspath(".")
+        base_path = dirname(__file__)
 
     return join(base_path, relative_path)
 


### PR DESCRIPTION
Adds a shortcut to run the app from the repository root, and fixes running `editor_app/app.py` from cwd other than `editor_app`